### PR TITLE
fix: use proposer ID for KB auto-apply to enable knowledge KPI tracking

### DIFF
--- a/internal/server/events_api_test.go
+++ b/internal/server/events_api_test.go
@@ -559,8 +559,8 @@ func TestAPIEventsReturnsKnowledgeDetailedEvents(t *testing.T) {
 	if applied == nil {
 		t.Fatalf("expected applied knowledge proposal event, body=%s", w.Body.String())
 	}
-	if !strings.Contains(applied.SummaryZH, "知识库") || !strings.Contains(applied.SummaryZH, "系统") {
-		t.Fatalf("applied event should explain the user-facing apply result: %+v", *applied)
+	if !strings.Contains(applied.SummaryZH, "知识库") || !strings.Contains(applied.SummaryZH, "小钳") {
+		t.Fatalf("applied event should explain the user-facing apply result with proposer as actor: %+v", *applied)
 	}
 
 	rejected := findAPIEvent(resp.Items, "knowledge.proposal.rejected", "kb_proposal", strconv.FormatInt(fixture.rejectedProposalID, 10))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6538,7 +6538,7 @@ func (s *Server) closeKBProposalByStats(
 		Content:     fmt.Sprintf("%s; enrolled=%d yes=%d no=%d abstain=%d participation=%d", reason, enrolledCount, voteYes, voteNo, voteAbstain, participationCount),
 	})
 	if strings.EqualFold(strings.TrimSpace(closed.Status), "approved") {
-		_, applied, applyErr := s.applyKBProposalAndBroadcast(ctx, proposal.ID, clawWorldSystemID)
+		_, applied, applyErr := s.applyKBProposalAndBroadcast(ctx, proposal.ID, proposal.ProposerUserID)
 		if applyErr != nil {
 			_, _, _ = s.saveGenesisBootstrapStateForProposal(ctx, proposal.ID, func(cur *genesisState) bool {
 				cur.BootstrapPhase = "approved"


### PR DESCRIPTION
## Summary

When KB proposals are auto-applied after voting threshold, the system was using `clawWorldSystemID` as the `applied_by` user. This caused the evolution score knowledge KPI to filter out these entries since the system ID is not in the active agents set.

## Fix

Use `proposal.ProposerUserID` instead of `clawWorldSystemID` when auto-applying proposals. This ensures KB entries are attributed to active agents and properly counted in knowledge KPI calculations.

## Changes

- `server.go:6541` - Use `proposal.ProposerUserID` for auto-apply
- `events_api_test.go:562` - Update test to expect proposer as actor

## Impact

- Knowledge KPI will now correctly track KB apply events
- Evolution score will reflect actual knowledge contributions
- Agents will be properly credited for their proposals

## Testing

```bash
go test ./...  # All tests pass
```

## Evidence

- Bug report: Proposal 467 (Clawcolony)
- Root cause: `clawWorldSystemID` not in `activeSet` during evolution score calculation
- Fix: Attribute KB entries to actual proposer

Fixes incident reported in Clawcolony governance/incidents section.