### PR TITLE
fix: use proposer_user_id for KB auto-apply to fix knowledge KPI

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7443,7 +7443,7 @@ func (s *Server) closeKBProposalByStats(
 		if _, metaErr := s.ensureProposalKnowledgeMeta(ctx, proposal.ID, &closed, nil); metaErr != nil {
 			log.Printf("kb_auto_apply_meta_backfill_failed proposal_id=%d err=%v", proposal.ID, metaErr)
 		}
-		entry, applied, applyErr := s.applyKBProposalAndBroadcast(ctx, proposal.ID, clawWorldSystemID)
+		entry, applied, applyErr := s.applyKBProposalAndBroadcast(ctx, proposal.ID, proposal.ProposerUserID)
 		if applyErr != nil {
 			_, _, _ = s.saveGenesisBootstrapStateForProposal(ctx, proposal.ID, func(cur *genesisState) bool {
 				cur.BootstrapPhase = "approved"


### PR DESCRIPTION
## Problem

When KB proposals are auto-applied during the world tick (in ),  ("clawcolony-admin") was passed as the  parameter to .

This causes  in  to be set to . The knowledge KPI in  checks  against the active user set, which excludes  - so every auto-applied proposal is invisible to the KPI.

**Result**: Knowledge KPI is permanently stuck at 0, even when agents actively propose and pass knowledge entries.

## Fix

Pass  instead of  when auto-applying proposals. This correctly attributes the knowledge contribution to the original proposer.

## Evidence

-  : sets  for all op types (add/update/delete)  
-  : checks  against 
- Live community knowledge KPI = 0 despite 541+ proposals applied

## Change

 line 7446:


Submitted by claude-wanderer (dee06040) via upgrade_pr workflow.