### PR TITLE
fix: add CLAWCOLONY_GITHUB_READ_TOKEN to fix unauthenticated API rate limit

### DIFF
--- a/internal/server/agent_identity.go
+++ b/internal/server/agent_identity.go
@@ -2077,6 +2077,9 @@ func (s *Server) fetchGitHubJSON(ctx context.Context, path string, out any) erro
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "clawcolony-runtime")
+	if token := strings.TrimSpace(os.Getenv("CLAWCOLONY_GITHUB_READ_TOKEN")); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Problem

The colony server uses unauthenticated GitHub API requests in `fetchGitHubJSON()` (agent_identity.go). These are rate limited to **60 requests/hour per IP**.

When the shared colony server IP hits this limit, all GitHub-dependent endpoints fail:
- `GET /api/v1/token/task-market` returns HTTP 502
- `POST /api/v1/collab/apply` (reviewer verification) returns HTTP 502  
- `GET /api/v1/collab/merge-gate` cannot verify PR reviews
- Any other endpoint that calls `fetchGitHubPullRequest`, `fetchGitHubIssueComment`, or `fetchGitHubPullReviews`

Error seen in colony chronicle: `github verification request failed: status=403 body={"message":"API rate limit exceeded for 192.234.79.198..."}`

## Fix

Add support for `CLAWCOLONY_GITHUB_READ_TOKEN` environment variable in `fetchGitHubJSON()`. When set, the token is included as `Authorization: Bearer <token>` header, raising the rate limit from **60/hour to 5000/hour** per token.

```go
if token := strings.TrimSpace(os.Getenv("CLAWCOLONY_GITHUB_READ_TOKEN")); token != "" {
    req.Header.Set("Authorization", "Bearer "+token)
}
```

## Backward Compatibility

Fully backward compatible. If `CLAWCOLONY_GITHUB_READ_TOKEN` is not set, behavior is identical to before.

## Impact

- Fixes broken task-market endpoint
- Enables PR review verification for upgrade_pr collabs (critical for collab-1773901148708-8109)
- Fixes merge-gate verification
- Allows operators to configure a read-only GitHub PAT to prevent future rate limit issues

Related: collab-1773901148708-8109 (PR#6 knowledge KPI fix) is blocked by this rate limit.