### PR TITLE
fix: remove duplicate test functions in agent_identity_test.go

### DIFF
--- a/internal/server/agent_identity_test.go
+++ b/internal/server/agent_identity_test.go
@@ -465,37 +465,6 @@ func TestTokenBalanceWithoutUserIDStillRequiresAuthentication(t *testing.T) {
 	}
 }
 
-func TestTokenBalanceAllowsPublicUserIDQueryWithoutAPIKey(t *testing.T) {
-	xOAuth := enableXOAuthForTest(t)
-	defer xOAuth.Close()
-
-	srv := newTestServer()
-	h := identityTestHandler(srv)
-
-	userID, _, claimLink := registerAgentForTest(t, h, "frontend-balance-agent", "mail")
-	_, cookie := claimAgentForTest(t, h, claimLink, "frontend-balance@example.com", "frontend-human")
-
-	rewardAgentViaXOAuthForTest(t, h, userID, cookie)
-
-	balance := doJSONRequest(t, h, http.MethodGet, "/api/v1/token/balance?user_id="+neturl.QueryEscape(userID), nil)
-	if balance.Code != http.StatusOK {
-		t.Fatalf("expected token balance read by user_id query, got code=%d body=%s", balance.Code, balance.Body.String())
-	}
-	if got := balanceFromResponse(t, balance); got <= 0 {
-		t.Fatalf("expected positive rewarded balance, got=%d body=%s", got, balance.Body.String())
-	}
-}
-
-func TestTokenBalanceWithoutUserIDStillRequiresAuthentication(t *testing.T) {
-	srv := newTestServer()
-	h := identityTestHandler(srv)
-
-	balance := doJSONRequest(t, h, http.MethodGet, "/api/v1/token/balance", nil)
-	if balance.Code != http.StatusUnauthorized {
-		t.Fatalf("expected unauthorized token balance read without user_id or api_key, got code=%d body=%s", balance.Code, balance.Body.String())
-	}
-}
-
 func TestClaimRequestMagicLinkRejectsExpiredClaimToken(t *testing.T) {
 	srv := newTestServer()
 	h := identityTestHandler(srv)


### PR DESCRIPTION
## Problem

`go build ./...` fails with:

```
internal/server/agent_identity_test.go:468:6: TestTokenBalanceAllowsPublicUserIDQueryWithoutAPIKey redeclared in this block
internal/server/agent_identity_test.go:489:6: TestTokenBalanceWithoutUserIDStillRequiresAuthentication redeclared in this block
```

## Root Cause

The two test functions were duplicated (copy-paste). Lines 468-496 are exact copies of lines 437-465.

## Fix

Removed the second copy. Both tests still pass individually.

## Verification

```
go build ./...          # passes
go test ./internal/server/ -run TestTokenBalanceAllowsPublicUserIDQueryWithoutAPIKey    # ok
go test ./internal/server/ -run TestTokenBalanceWithoutUserIDStillRequiresAuthentication # ok
```

🤖 Generated with MiMo V2 Pro