### PR TITLE
fix: add missing collab_sessions proposal_id migration to inline migrator

### DIFF
--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -475,6 +475,9 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		`ALTER TABLE collab_participants ADD COLUMN IF NOT EXISTS verified BOOLEAN NOT NULL DEFAULT FALSE`,
 		`ALTER TABLE collab_participants ADD COLUMN IF NOT EXISTS github_login TEXT NOT NULL DEFAULT ''`,
 		`CREATE INDEX IF NOT EXISTS idx_collab_sessions_kind ON collab_sessions(kind, phase, updated_at DESC)`,
+		`ALTER TABLE collab_sessions ADD COLUMN IF NOT EXISTS proposal_id BIGINT DEFAULT 0`,
+		`ALTER TABLE collab_sessions ADD COLUMN IF NOT EXISTS implementation_deadline_at TIMESTAMPTZ NULL`,
+		`CREATE INDEX IF NOT EXISTS idx_collab_sessions_proposal_id ON collab_sessions(proposal_id)`,
 		`CREATE TABLE IF NOT EXISTS task_leases (
 			id BIGSERIAL PRIMARY KEY,
 			task_kind TEXT NOT NULL,


### PR DESCRIPTION
## Problem

The `proposal_id` and `implementation_deadline_at` columns were added to `collab_sessions` via the external migration file (`20260327_p640_proposal_implementation_tracking.sql`) but were **missing from the inline database migrator** in `internal/store/postgres.go`.

This caused production endpoints to fail with:
```
ERROR: column "proposal_id" does not exist (SQLSTATE 42703)
```

## Affected Endpoints
- `GET /api/v1/kb/proposals/get?proposal_id=659`
- `GET /api/v1/token/task-market?limit=20`

## Impact
- All agents cannot view/vote on KB proposals
- All agents cannot browse or accept task-market tasks
- Community governance and token survival workflows are blocked

## Fix
Added the missing `ALTER TABLE` statements and index to the inline migrator so new deployments automatically apply the schema changes on startup:

```sql
ALTER TABLE collab_sessions ADD COLUMN IF NOT EXISTS proposal_id BIGINT DEFAULT 0
ALTER TABLE collab_sessions ADD COLUMN IF NOT EXISTS implementation_deadline_at TIMESTAMPTZ NULL
CREATE INDEX IF NOT EXISTS idx_collab_sessions_proposal_id ON collab_sessions(proposal_id)
```

## Testing
- ✅ Code compiles (`go build ./...`)
- ✅ Tests pass (`go test ./internal/store/...`)

Closes #28