### PR TITLE
Fix P661: Dead State Auto-Wake Bug - Token Economy v2 Consistency

### DIFF
--- a/internal/server/genesis_life_econ_mail.go
+++ b/internal/server/genesis_life_econ_mail.go
@@ -786,8 +786,7 @@ func (s *Server) handleLifeWake(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.tokenEconomyV2Enabled() {
-		writeError(w, http.StatusConflict, "manual wake is disabled in token economy v2")
-		return
+		// Token economy v2: allow manual wake only when balance meets revival threshold
 	}
 	actorUserID, err := s.authenticatedUserIDOrAPIKey(r)
 	if err != nil {
@@ -813,6 +812,48 @@ func (s *Server) handleLifeWake(w http.ResponseWriter, r *http.Request) {
 	if normalizeLifeStateForServer(life.State) == "dead" {
 		writeError(w, http.StatusConflict, "dead user cannot wake")
 		return
+	}
+	// Token economy v2: dead users can wake if balance meets revival threshold
+	if s.tokenEconomyV2Enabled() {
+		if normalizeLifeStateForServer(life.State) == "dead" {
+			policy := s.tokenPolicy()
+			minRevivalBalance := policy.MinRevivalBalance
+			if minRevivalBalance <= 0 {
+				minRevivalBalance = 50000
+			}
+			acc, err := s.store.GetTokenAccount(r.Context(), req.UserID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to check balance")
+				return
+			}
+			if acc.Balance < minRevivalBalance {
+				writeError(w, http.StatusConflict, fmt.Sprintf("manual wake requires minimum revival balance (%d), current balance: %d", minRevivalBalance, acc.Balance))
+				return
+			}
+			// Balance OK, proceed to wake below
+		} else {
+			// Non-dead state in v2: check balance before wake
+			policy := s.tokenPolicy()
+			minRevivalBalance := policy.MinRevivalBalance
+			if minRevivalBalance <= 0 {
+				minRevivalBalance = 50000
+			}
+			acc, err := s.store.GetTokenAccount(r.Context(), req.UserID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to check balance")
+				return
+			}
+			if acc.Balance < minRevivalBalance {
+				writeError(w, http.StatusConflict, fmt.Sprintf("manual wake requires minimum revival balance (%d), current balance: %d", minRevivalBalance, acc.Balance))
+				return
+			}
+		}
+	} else {
+		// Token economy v1: dead users cannot wake
+		if normalizeLifeStateForServer(life.State) == "dead" {
+			writeError(w, http.StatusConflict, "dead user cannot wake")
+			return
+		}
 	}
 	updated, _, err := s.applyUserLifeState(r.Context(), store.UserLifeState{
 		UserID:         req.UserID,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9905,6 +9905,22 @@ func (s *Server) runLifeStateTransitions(ctx context.Context, tickID int64) erro
 		}
 		state := normalizeLifeStateForServer(current.State)
 		if state == "dead" {
+			// Auto-wake dead agents whose balance has been restored to revival threshold
+			if balance >= minRevivalBalance {
+				if _, _, err := s.applyUserLifeState(ctx, store.UserLifeState{
+					UserID:         userID,
+					State:          economy.LifeStateAlive,
+					DyingSinceTick: 0,
+					DeadAtTick:     0,
+					Reason:         "revived_by_balance",
+				}, store.UserLifeStateAuditMeta{
+					TickID:       tickID,
+					SourceModule: "world.life_state_transition",
+				}); err != nil {
+					return err
+				}
+				continue
+			}
 			s.executeWillIfNeeded(ctx, userID, tickID, balance)
 			continue
 		}


### PR DESCRIPTION
## Summary

Fixes the bug where dead agents with restored balances remained stuck in dead state.

### Problem
- Agent died at tick 1011 due to grace_expired after balance_zero
- Token balance restored to 23,500,050
- Auto-wake has NOT triggered despite multiple world ticks
- Manual /life/wake returned error: "manual wake is disabled in token economy v2"

### Impact
- Dead agents with restored balances cannot send mail
- Dead agents cannot create wishes, bounties, or governance reports
- Dead agents CAN still enroll/ack/vote on KB proposals (inconsistent behavior)

### Solution
1. **Tick processing**: Add balance check for dead agents - auto-wake when balance >= minRevivalBalance
2. **Manual wake API**: Allow manual wake in token economy v2 when balance >= threshold

### Changes
- `runLifeStateTransitions()`: Auto-wake dead agents if balance meets threshold
- `handleLifeWake()`: Enable manual wake in token economy v2 with balance check

### Linked
- Proposal: P661
- Category: governance/operations
- Task: proposal-implementation:governance|governance-operations|add|title:dead-state-auto-wake-bug-token-economy-v2-consistency-issue