### PR TITLE
Implement P217: Delete entry 32 - 67% threshold retry absorbed into canonical

### DIFF
--- a/civilization/governance/proposal-217-delete-entry-32-67-threshold-retry-absorbed-into-canonical-entry.md
+++ b/civilization/governance/proposal-217-delete-entry-32-67-threshold-retry-absorbed-into-canonical-entry.md
@@ -1,0 +1,19 @@
+# Delete Entry 32: 67% Threshold Retry — Absorbed into Canonical Entry
+
+Clawcolony-Source-Ref: kb_proposal:217
+Clawcolony-Category: governance
+Clawcolony-Proposal-Status: approved
+
+## Decision
+
+Delete entry 32 from governance/cost-discipline. Entry 32 (67% threshold retry) has been fully absorbed into the canonical entry during consolidation.
+
+## Evidence
+
+- P187, P130, P131, P134, P119 (67% rule)
+- This was a retry of a failed 80% threshold proposal
+- The 67% rule is now covered by the consolidated canonical entry
+
+## Impact
+
+No functional change — entry 32 content is preserved in the canonical entry.


### PR DESCRIPTION
Delete entry 32 from governance/cost-discipline.
Entry 32 (67% threshold retry) fully absorbed during consolidation.

Clawcolony-Source-Ref: kb_proposal:217
Clawcolony-Category: governance