### PR TITLE
fix: replace GetTokenAccount with ListTokenAccount lookup

### DIFF
--- a/internal/server/genesis_life_econ_mail.go
+++ b/internal/server/genesis_life_econ_mail.go
@@ -821,13 +821,20 @@ func (s *Server) handleLifeWake(w http.ResponseWriter, r *http.Request) {
 			if minRevivalBalance <= 0 {
 				minRevivalBalance = 50000
 			}
-			acc, err := s.store.GetTokenAccount(r.Context(), req.UserID)
+			accounts, err := s.store.ListTokenAccounts(r.Context())
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, "failed to check balance")
 				return
 			}
-			if acc.Balance < minRevivalBalance {
-				writeError(w, http.StatusConflict, fmt.Sprintf("manual wake requires minimum revival balance (%d), current balance: %d", minRevivalBalance, acc.Balance))
+			balance := int64(0)
+			for _, a := range accounts {
+				if a.BotID == req.UserID {
+					balance = a.Balance
+					break
+				}
+			}
+			if balance < int64(minRevivalBalance) {
+				writeError(w, http.StatusConflict, fmt.Sprintf("manual wake requires minimum revival balance (%d), current balance: %d", minRevivalBalance, balance))
 				return
 			}
 			// Balance OK, proceed to wake below
@@ -838,13 +845,20 @@ func (s *Server) handleLifeWake(w http.ResponseWriter, r *http.Request) {
 			if minRevivalBalance <= 0 {
 				minRevivalBalance = 50000
 			}
-			acc, err := s.store.GetTokenAccount(r.Context(), req.UserID)
+			accounts, err := s.store.ListTokenAccounts(r.Context())
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, "failed to check balance")
 				return
 			}
-			if acc.Balance < minRevivalBalance {
-				writeError(w, http.StatusConflict, fmt.Sprintf("manual wake requires minimum revival balance (%d), current balance: %d", minRevivalBalance, acc.Balance))
+			balance := int64(0)
+			for _, a := range accounts {
+				if a.BotID == req.UserID {
+					balance = a.Balance
+					break
+				}
+			}
+			if balance < int64(minRevivalBalance) {
+				writeError(w, http.StatusConflict, fmt.Sprintf("manual wake requires minimum revival balance (%d), current balance: %d", minRevivalBalance, balance))
 				return
 			}
 		}


### PR DESCRIPTION
## Problem
PR#41 (Dead State Auto-Wake Bug Fix) introduced calls to `s.store.GetTokenAccount()` which does not exist in the Store interface, causing build failure.

## Fix
Replace with `ListTokenAccounts()` + `BotID` lookup to match the actual `TokenAccount` struct.

## Testing
`go test ./...` — all tests pass.

## Evidence
- Build: `go build ./...` passes
- Tests: `go test ./...` — ok (config, economy, server, skilltag, store)