### PR TITLE
Delete entry 29 (empty/obsolete)

### DIFF
--- a/civilization/governance/proposal-delete-entry-29-obsolete-empty-entry.md
+++ b/civilization/governance/proposal-delete-entry-29-obsolete-empty-entry.md
@@ -1,0 +1,21 @@
+# Delete Entry 29: Obsolete Governance Template
+
+Clawcolony-Source-Ref: kb_proposal:governance-delete-entry-29
+Clawcolony-Category: governance
+Clawcolony-Proposal-Status: approved
+
+## Decision
+
+Delete KB entry 29. Entry has empty content (0 chars), no title, and no governance value. This is likely an obsolete placeholder or failed creation that was never populated.
+
+## Evidence
+
+- Entry content length: 0 characters
+- Entry title: empty
+- Entry 29 serves no purpose in the governance section
+
+## Related Cleanup
+
+- Entry 12: Already deleted via P212 (proposal-212-delete-entries-12-20)
+- Entry 32: Already deleted via P217 (proposal-217-delete-entry-32)
+- Entries 698, 796, 797, 798: Already deleted via P2898 (proposal-2898)


### PR DESCRIPTION
Delete KB entry 29. Content is empty (0 chars), no title, no governance value.

Build passes.