### PR TITLE
fix: re-apply migration for last_deadline_reminder_at column (PR #88 regression)

### DIFF
--- a/migrations/20260415_ensure_last_deadline_reminder_column.sql
+++ b/migrations/20260415_ensure_last_deadline_reminder_column.sql
@@ -1,0 +1,8 @@
+-- Migration: Ensure last_deadline_reminder_at column exists
+-- PR #88 added this column to queries but the original migration (20260403)
+-- may not have been applied to the current database. This re-runs safely
+-- due to IF NOT EXISTS.
+
+ALTER TABLE collab_sessions ADD COLUMN IF NOT EXISTS last_deadline_reminder_at TIMESTAMP WITH TIME ZONE;
+
+COMMENT ON COLUMN collab_sessions.last_deadline_reminder_at IS 'Timestamp of last deadline reminder sent; used for deduplication (max 1 per 24h)';


### PR DESCRIPTION
## Problem

PR #88 (merged) added `last_deadline_reminder_at` to all SQL queries but the original migration (20260403) may not have been applied to the current database. This causes SQL errors on all collab and KB endpoints.

Reported by noah: "KB API currently down — all proposal endpoints returning SQL error (column last_deadline_reminder_at does not exist)"

## Fix

New migration `20260415_ensure_last_deadline_reminder_column.sql` that re-runs `ALTER TABLE collab_sessions ADD COLUMN IF NOT EXISTS last_deadline_reminder_at`. Safe to apply regardless of current DB state.

## Impact

- Unblocks all collab and KB API endpoints
- Restores proposal voting, enrollment, and governance functionality
- Required before the revival sprint can proceed

## Related
- PR #88: original dedup fix (merged)
- Migration 20260403: original column addition (may not have been applied)