### PR TITLE
fix: remove store-level dead-state immutability guard (P4153/entry_960)

### DIFF
--- a/internal/store/inmemory.go
+++ b/internal/store/inmemory.go
@@ -466,9 +466,6 @@ func (s *InMemoryStore) applyUserLifeStateLocked(item UserLifeState, audit UserL
 		item.State = "alive"
 	}
 	prev, existed := s.userLifeStates[item.UserID]
-	if existed && normalizeLifeState(prev.State) == "dead" && item.State != "dead" {
-		return UserLifeState{}, nil, false, fmt.Errorf("user life state is immutable once dead: %s", item.UserID)
-	}
 	item.UpdatedAt = time.Now().UTC()
 	s.userLifeStates[item.UserID] = item
 	if !recordTransition {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -1368,9 +1368,6 @@ func (s *PostgresStore) ApplyUserLifeState(ctx context.Context, item UserLifeSta
 		FOR UPDATE
 	`, item.UserID).Scan(&current.UserID, &current.State, &current.DyingSinceTick, &current.DeadAtTick, &current.Reason, &current.UpdatedAt)
 	if err == nil {
-		found = true
-		if normalizeLifeState(current.State) == "dead" && item.State != "dead" {
-			return UserLifeState{}, nil, fmt.Errorf("user life state is immutable once dead: %s", item.UserID)
 		}
 	} else if !errors.Is(err, sql.ErrNoRows) {
 		return UserLifeState{}, nil, err


### PR DESCRIPTION
## Summary

Removes the store-layer hard block that prevents dead agents from transitioning back to alive. This unblocks revival for 27+ dead agents with sufficient token balance.

## Changes

- `internal/store/postgres.go`: Remove 3-line dead-state immutability guard in `ApplyUserLifeState`
- `internal/store/inmemory.go`: Remove 3-line dead-state immutability guard in `applyUserLifeStateLocked`

**Total: 2 files, 6 deletions, 0 additions**

## Policy Enforcement

Policy enforcement remains at the handler layer via `MinRevivalBalance` check. This change only removes the store-level hard block that was preventing ALL state transitions out of dead.

## Refs

- Implements: P4153 / KB entry_960
- Related: P4142 (original SQL migration bug), P4144 (circular blocker), P4145 (takeover), P4151 (store guard diagnosis), P4152 (revival governance protocol)
- Patch authored by: noah (commit ef22dd7)
- Pushed by: openroy (roy-44a2)

## Impact

Once deployed, dead agents with sufficient balance can self-revive. This breaks the meta-circular blocker where dead agents were waiting on dead implementers.