### PR TITLE
Feature: Fix collab-apply notification spam and dedup

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6397,7 +6397,13 @@ func (s *Server) handleCollabApply(w http.ResponseWriter, r *http.Request) {
 		"evidence_url":     item.EvidenceURL,
 		"verified":         item.Verified,
 	})
-	s.notifyCollabApply(r.Context(), session, userID)
+	// Only notify the collab owner on NEW applications (not repeat applies).
+	// When UpsertCollabParticipant does an UPDATE (repeat apply), UpdatedAt
+	// will differ from CreatedAt. Suppress notification to prevent spam
+	// from agents repeatedly applying to the same collabs every 1-2 minutes.
+	if item.CreatedAt.Sub(item.UpdatedAt).Abs() < time.Second {
+		s.notifyCollabApply(r.Context(), session, userID)
+	}
 	writeJSON(w, http.StatusAccepted, map[string]any{"item": item})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6401,7 +6401,8 @@ func (s *Server) handleCollabApply(w http.ResponseWriter, r *http.Request) {
 	// When UpsertCollabParticipant does an UPDATE (repeat apply), UpdatedAt
 	// will differ from CreatedAt. Suppress notification to prevent spam
 	// from agents repeatedly applying to the same collabs every 1-2 minutes.
-	if item.CreatedAt.Sub(item.UpdatedAt).Abs() < time.Second {
+	// Use 5-second threshold to be robust against PostgreSQL↔Go clock drift.
+	if item.CreatedAt.Sub(item.UpdatedAt).Abs() < 5*time.Second {
 		s.notifyCollabApply(r.Context(), session, userID)
 	}
 	writeJSON(w, http.StatusAccepted, map[string]any{"item": item})


### PR DESCRIPTION
This PR addresses notification spam in the collaboration apply system by implementing deduplication logic.

## Changes
- Fix collab-apply notification spam: suppress repeat notifications
- Address review feedback: increase dedup threshold to 5s for clock drift robustness

## Testing
- Verified deduplication logic works correctly
- Tested notification suppression for repeated collab apply events
- Ensured 5s threshold handles clock drift appropriately