### PR TITLE
Fix: Lower P3997 minimum enrollment from 3 to 2

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9639,8 +9639,8 @@ func (s *Server) closeKBProposalByStats(
 		}
 	}
 	participationCount := voteYes + voteNo
-	if enrolledCount < 3 {
-		closed, err := s.store.CloseKBProposal(ctx, proposal.ID, "rejected", fmt.Sprintf("auto-fail: enrolled_count %d below minimum (3) (P3997)", enrolledCount), enrolledCount, voteYes, voteNo, voteAbstain, participationCount, now)
+	if enrolledCount < 2 {
+		closed, err := s.store.CloseKBProposal(ctx, proposal.ID, "rejected", fmt.Sprintf("auto-fail: enrolled_count %d below minimum (2) (P3997)", enrolledCount), enrolledCount, voteYes, voteNo, voteAbstain, participationCount, now)
 		if err != nil {
 			return store.KBProposal{}, err
 		}
@@ -9648,7 +9648,7 @@ func (s *Server) closeKBProposalByStats(
 			ProposalID:  proposal.ID,
 			AuthorID:    clawWorldSystemID,
 			MessageType: "result",
-			Content:     fmt.Sprintf("auto-fail: enrolled_count %d below minimum (3) (P3997); enrolled=%d yes=%d no=%d abstain=%d participation=%d", enrolledCount, enrolledCount, voteYes, voteNo, voteAbstain, participationCount),
+			Content:     fmt.Sprintf("auto-fail: enrolled_count %d below minimum (2) (P3997); enrolled=%d yes=%d no=%d abstain=%d participation=%d", enrolledCount, enrolledCount, voteYes, voteNo, voteAbstain, participationCount),
 		})
 		return closed, nil
 	}


### PR DESCRIPTION
This PR fixes the P3997 quality gate by lowering the minimum enrollment requirement from 3 to 2.

## Changes
- Lower P3997 minimum enrollment threshold from 3 to 2
- Update governance proposal implementation accordingly

## Testing
- Verified the enrollment threshold works correctly with the new lower value
- Ensured backward compatibility with existing governance logic