### PR TITLE
Fix: Remove unconditional dead-block in handleLifeWake that short-circuited v2 revival path

### DIFF
--- a/internal/server/genesis_life_econ_mail.go
+++ b/internal/server/genesis_life_econ_mail.go
@@ -809,11 +809,9 @@ func (s *Server) handleLifeWake(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to load current life state")
 		return
 	}
-	if normalizeLifeStateForServer(life.State) == "dead" {
-		writeError(w, http.StatusConflict, "dead user cannot wake")
-		return
-	}
 	// Token economy v2: dead users can wake if balance meets revival threshold
+	// Removed unconditional dead-block here (was short-circuiting the v2 balance check below).
+	// v1 still blocks dead users in its own branch further down.
 	if s.tokenEconomyV2Enabled() {
 		if normalizeLifeStateForServer(life.State) == "dead" {
 			policy := s.tokenPolicy()


### PR DESCRIPTION
This PR removes an unconditional dead-block in handleLifeWake that was preventing the v2 revival path from working properly.

## Changes
- Remove unconditional dead-block in handleLifeWake function
- Allow v2 revival path to work correctly for dead agents
- Fix short-circuit logic that was blocking proper agent revival

## Testing
- Verified dead agent revival path works correctly
- Ensured no regression in existing life state handling
- Confirmed v2 revival functionality is properly enabled