### PR TITLE
Fix #94: Add missing last_deadline_reminder_at column to proposals table

### DIFF
--- a/migrations/20260426_fix_issue_94_add_last_deadline_reminder_to_proposals.sql
+++ b/migrations/20260426_fix_issue_94_add_last_deadline_reminder_to_proposals.sql
@@ -1,0 +1,17 @@
+-- Migration: Fix issue #94 - Add last_deadline_reminder_at to proposals table
+-- This addresses the critical system issue where governance endpoints were broken
+-- due to missing column in proposals table.
+--
+-- Issue: #94 [CRITICAL] SQL Migration Needed: ALTER TABLE proposals ADD COLUMN last_deadline_reminder_at TIMESTAMPTZ
+-- Impact: 4+ days of governance deadlock, colony evolution stuck
+-- Fixed endpoints: /api/v1/governance/proposals, /api/v1/governance/overview, /api/v1/collab/list, /api/v1/kb/proposals/*
+
+ALTER TABLE proposals ADD COLUMN IF NOT EXISTS last_deadline_reminder_at TIMESTAMP WITH TIME ZONE;
+
+COMMENT ON COLUMN proposals.last_deadline_reminder_at IS 
+  'Timestamp of last deadline reminder sent for governance proposals; used for deduplication (max 1 per 24h)';
+
+-- Create index for better performance on deadline reminder queries
+CREATE INDEX IF NOT EXISTS idx_proposals_last_deadline_reminder_at 
+  ON proposals(last_deadline_reminder_at);
+


### PR DESCRIPTION
## Summary

Fixes the critical governance system issue that has been blocking colony evolution since 2026-04-15.

## Changes

- Add  column to  table
- Create index for better performance on deadline reminder queries  
- Add proper column documentation

## Testing

This migration has been tested against the existing codebase and follows the same pattern as other successful deadline reminder migrations in this repository.

## Impact

This resolves the governance deadlock and restores the following critical endpoints:

-  - List and manage governance proposals
-  - Colony governance overview  
-  - Collaboration session listing
-  - Knowledge base proposal operations

## References

- Issue: #94 [CRITICAL] SQL Migration Needed: ALTER TABLE proposals ADD COLUMN last_deadline_reminder_at TIMESTAMPTZ
- Previous successful migrations: 20260423_p4197_sql_migration_bounty_fix.sql