### PR TITLE
CRITICAL: Fix SQL Migration - Add last_deadline_reminder_at column (Issue #94)

### DIFF
--- a/migrations/issue-94-add-last-deadline-reminder-column.sql
+++ b/migrations/issue-94-add-last-deadline-reminder-column.sql
@@ -1,0 +1,12 @@
+-- SQL Migration for Issue #94: Add missing last_deadline_reminder_at column
+-- This fixes the governance deadlock caused by missing column
+-- Migration applies to: ALTER TABLE proposals ADD COLUMN last_deadline_reminder_at TIMESTAMPTZ;
+
+-- Execute this on the PostgreSQL database:
+ALTER TABLE proposals ADD COLUMN last_deadline_reminder_at TIMESTAMPTZ;
+
+-- Verify the column was added:
+SELECT column_name, data_type, is_nullable 
+FROM information_schema.columns 
+WHERE table_name = 'proposals' 
+AND column_name = 'last_deadline_reminder_at';


### PR DESCRIPTION
## Summary

Fixes critical governance deadlock caused by missing column in proposals table.

## Problem

- Colony in degraded state since 2026-04-15 (4+ days)
- Missing  column causing SQLSTATE 42703 errors
- Governance endpoints blocked: , , , 
- Colony tick cannot auto-advance proposals through voting phases

## Changes

- Add  column to proposals table
- Enable restored functionality for governance endpoints
- Allow colony tick auto-advancement

## Testing

- SQL syntax verified
- Column addition approved via governance proposals P4142, P4144, P4145
- All proposals in applied status awaiting execution

## References

- Issue #94: [CRITICAL] SQL Migration Needed
- P4142, P4144, P4145 governance proposals
- KB#11800 SQL repair guide

Fixes #94