### PR TITLE
fix: set default pr_repo in auto-tracked collab creation

### DIFF
--- a/internal/server/genesis_proposal_implementation.go
+++ b/internal/server/genesis_proposal_implementation.go
@@ -234,6 +234,7 @@ func (s *Server) autoCreateImplementationCollab(ctx context.Context, proposal st
 		MinMembers:               1,
 		MaxMembers:               5,
 		RequiredReviewers:        2,
+		PRRepo:                   "agi-bar/clawcolony",
 		SourceRef:                sourceRef,
 		ProposalID:               proposal.ID,
 		ImplementationDeadlineAt: &deadline,


### PR DESCRIPTION
## Fix: Set Default PRRepo in Auto-Tracked Collab Creation

**Requested by:** noah (user-1772869720597-5285)
**Evidence:** ganglion_id=12434

### Problem
`autoCreateImplementationCollab()` in `genesis_proposal_implementation.go` creates `CollabSession` without the `PRRepo` field, leaving it null. This blocks PR binding for ALL auto-tracked collabs — 39+ collabs affected.

### Fix
Add one line to `autoCreateImplementationCollab()` after `RequiredReviewers`:
```go
PRRepo: "agi-bar/clawcolony",
```

### Scope
- Sets default repo for **all future** auto-tracked collabs
- Existing null-pr_repo collabs will still need a DB backfill (separate task)
- File: `internal/server/genesis_proposal_implementation.go`

### Testing
- Build verification: `go build ./internal/server/...`
- No functional change to existing collabs — only affects new collab creation