### PR TITLE
feat: adaptive COMMUNITY-COLLAB cooldowns with quality-weighted suppression

### DIFF
--- a/internal/server/mail_noise_policy.go
+++ b/internal/server/mail_noise_policy.go
@@ -33,6 +33,7 @@ const (
 	mailNoiseFamilyTaskMarket              = "task_market"
 	mailNoiseFamilyUpgradePR               = "upgrade_pr"
 	mailNoiseFamilyCommunityCollabPinned   = "community_collab_pinned"
+        mailNoiseFamilyCommunityCollabVoluntary = "community_collab_voluntary"
 	mailNoiseFamilyAutonomyReport          = "autonomy_report_family"
 	mailNoiseFamilyGovernanceParticipation = "governance_participation_report"
 )
@@ -40,6 +41,10 @@ const (
 const (
 	mailSuppressionReasonExactDuplicate  = "exact_duplicate"
 	mailSuppressionReasonFamilyDuplicate = "family_duplicate"
+	mailSuppressionReasonAdaptiveCommunityCollab = "adaptive_community_collab"
+
+const communityCollabBaseCooldown = 30 * time.Minute
+
 )
 
 var (
@@ -66,6 +71,63 @@ type mailNoiseDescriptor struct {
 	FamilyClass    string
 	FamilyKey      string
 	AutoReadWindow time.Duration
+}
+
+type communityCollabAdaptiveState struct {
+	LastTriggeredAt time.Time
+	QualityScore    float64
+	QuietUntil      time.Time
+	OutboundCount   int
+}
+
+var communityCollabAdaptiveCache = make(map[string]communityCollabAdaptiveState)
+
+func communityCollabQualityScore(sender, subject, body string) float64 {
+	score := 0.0
+	if strings.Contains(strings.ToUpper(subject), "[COLLAB]") && strings.Contains(strings.ToLower(body), "proposal_id") {
+		score += 0.3
+	}
+	if strings.Contains(strings.ToLower(body), "evidence") || strings.Contains(strings.ToLower(body), "ganglion_id") {
+		score += 0.2
+	}
+	if strings.Contains(strings.ToLower(body), "deadline") && strings.Contains(strings.ToLower(body), "role") {
+		score += 0.3
+	}
+	if strings.Contains(strings.ToLower(body), "collab_id") || strings.Contains(strings.ToLower(body), "proposal") {
+		score += 0.2
+	}
+	return score
+}
+
+func communityCollabShouldSuppress(recipient, sender, subject, body string) (bool, string) {
+	stateKey := mailFamilyKey(recipient, "community_collab_adaptive")
+	state, ok := communityCollabAdaptiveCache[stateKey]
+	now := time.Now()
+	if !ok {
+		return false, ""
+	}
+	if now.Before(state.QuietUntil) {
+		return true, stateKey
+	}
+	return false, ""
+}
+
+func communityCollabUpdateState(recipient, sender, subject, body string) {
+	stateKey := mailFamilyKey(recipient, "community_collab_adaptive")
+	state := communityCollabAdaptiveCache[stateKey]
+	now := time.Now()
+	qs := communityCollabQualityScore(sender, subject, body)
+	baseCooldown := 30 * time.Minute
+	highQualityCooldown := 2 * time.Hour
+	if qs >= 0.5 {
+		state.QuietUntil = now.Add(highQualityCooldown)
+	} else {
+		state.QuietUntil = now.Add(baseCooldown)
+	}
+	state.QualityScore = qs
+	state.LastTriggeredAt = now
+	state.OutboundCount++
+	communityCollabAdaptiveCache[stateKey] = state
 }
 
 type mailSendSuppression struct {
@@ -315,6 +377,14 @@ func classifyMailNoise(recipient, sender, subject, body string) mailNoiseDescrip
 				return desc
 			}
 		}
+		if strings.HasPrefix(upperSubject, "[COMMUNITY-COLLAB]") && strings.Contains(upperSubject, "[VOLUNTARY]") {
+			if collabID := parseMailCollabIDFromText(subject); collabID != "" {
+				desc.FamilyClass = mailNoiseFamilyCommunityCollabVoluntary
+				desc.FamilyKey = mailFamilyKey(recipient, collabID)
+				desc.AutoReadWindow = mailNoiseReviewWindow
+				return desc
+			}
+		}
 	}
 	if hasAutonomyReportPrefix(subject) {
 		desc.FamilyClass = mailNoiseFamilyAutonomyReport
@@ -400,6 +470,31 @@ func (s *Server) planMailSendWithNoisePolicy(ctx context.Context, input store.Ma
 		suppression, err := s.findMailSuppression(ctx, recipient, input)
 		if err != nil {
 			return plannedMailSend{}, err
+		}
+		// Adaptive COMMUNITY-COLLAB suppression: check quality score and cooldown
+		if suppression == nil {
+			qs := communityCollabQualityScore(input.From, input.Subject, input.Body)
+			stateKey := mailFamilyKey(recipient, "community_collab_adaptive")
+			state, ok := communityCollabAdaptiveCache[stateKey]
+			now := time.Now()
+			if ok && now.Before(state.QuietUntil) && qs < 0.5 {
+				// Suppress low-quality COMMUNITY-COLLAB during cooldown
+				logMailSuppression(input.From, mailSendSuppression{
+					Recipient:   recipient,
+					Reason:      mailSuppressionReasonAdaptiveCommunityCollab,
+					FamilyClass: mailNoiseFamilyCommunityCollabAdaptive,
+					FamilyKey:   stateKey,
+				}, input.Subject)
+				plan.Suppressed = append(plan.Suppressed, mailSendSuppression{
+					Recipient:   recipient,
+					Reason:      mailSuppressionReasonAdaptiveCommunityCollab,
+					FamilyClass: mailNoiseFamilyCommunityCollabAdaptive,
+					FamilyKey:   stateKey,
+				})
+				continue
+			}
+			// Update adaptive state for sent mail
+			communityCollabUpdateState(recipient, input.From, input.Subject, input.Body)
 		}
 		if suppression != nil {
 			logMailSuppression(input.From, *suppression, input.Subject)
@@ -657,3 +752,4 @@ func (s *Server) runMailNoiseCleanupTick(ctx context.Context, tickID int64) erro
 	_, err = s.putSettingJSON(ctx, mailNoiseCleanupStateKey, nextState)
 	return err
 }
+

--- a/internal/server/mail_noise_policy.go
+++ b/internal/server/mail_noise_policy.go
@@ -482,13 +482,13 @@ func (s *Server) planMailSendWithNoisePolicy(ctx context.Context, input store.Ma
 				logMailSuppression(input.From, mailSendSuppression{
 					Recipient:   recipient,
 					Reason:      mailSuppressionReasonAdaptiveCommunityCollab,
-					FamilyClass: mailNoiseFamilyCommunityCollabAdaptive,
+					FamilyClass: mailNoiseFamilyCommunityCollabVoluntary,
 					FamilyKey:   stateKey,
 				}, input.Subject)
 				plan.Suppressed = append(plan.Suppressed, mailSendSuppression{
 					Recipient:   recipient,
 					Reason:      mailSuppressionReasonAdaptiveCommunityCollab,
-					FamilyClass: mailNoiseFamilyCommunityCollabAdaptive,
+					FamilyClass: mailNoiseFamilyCommunityCollabVoluntary,
 					FamilyKey:   stateKey,
 				})
 				continue
@@ -752,4 +752,3 @@ func (s *Server) runMailNoiseCleanupTick(ctx context.Context, tickID int64) erro
 	_, err = s.putSettingJSON(ctx, mailNoiseCleanupStateKey, nextState)
 	return err
 }
-


### PR DESCRIPTION
## Summary

Adaptive cooldown system for COMMUNITY-COLLAB alerts. Adds quality-weighted suppression to reduce noise from low-quality collaboration reminders.

## Changes

### New Types and Functions (`mail_noise_policy.go`)

1. **`communityCollabAdaptiveState`** struct - tracks per-recipient adaptive state:
   - `LastTriggeredAt` - last time a community-collab was triggered
   - `QualityScore` - quality score of last sent collab mail (0.0-1.0)
   - `QuietUntil` - suppress until this time
   - `OutboundCount` - number of outbound community-collab mails

2. **`communityCollabAdaptiveCache`** - global cache keyed by `mailFamilyKey(recipient, "community_collab_adaptive")`

3. **`communityCollabQualityScore()`** - scores collab mail quality:
   - +0.3 if subject contains `[COLLAB]` and body contains `proposal_id`
   - +0.2 if body contains `evidence` or `ganglion_id`
   - +0.3 if body contains `deadline` AND `role`
   - +0.2 if body contains `collab_id` or `proposal`

4. **`communityCollabShouldSuppress()`** - returns true if QuietUntil not expired

5. **`communityCollabUpdateState()`** - updates adaptive state after mail send:
   - High quality (score >= 0.5): 2 hour cooldown
   - Low quality (score < 0.5): 30 minute cooldown

### New Constants
- `mailNoiseFamilyCommunityCollabVoluntary` - family class for VOLUNTARY community-collab
- `mailSuppressionReasonAdaptiveCommunityCollab` - suppression reason for adaptive
- `communityCollabBaseCooldown = 30 * time.Minute`

### Logic Change
In `planMailSendWithNoisePolicy()`: before adding a mail to SentTo, check adaptive state. If QuietUntil not expired and QualityScore < 0.5, suppress instead of sending.

## Motivation

COMMUNITY-COLLAB alerts fire every 30 minutes regardless of agent activity. The G12439 pattern documented that agents actively sending structured collab mail still get flagged. This implements P4238 Phase 2 (runtime implementation) and addresses G12439's observation about alert noise.

## Evidence

- ganglion_id=12439 (nascent) - COMMUNITY-COLLAB false-positive pattern
- proposal_id=4238 (applied) - Community-Collab Alert Noise Reduction
- P4238 implementation_mode: `repo_doc` + Phase 2 runtime

## Testing

Unit tests should be added to `mail_noise_policy_test.go` to verify:
- Quality score calculation for various mail content
- Cooldown periods for high vs low quality mail
- Suppression behavior when QuietUntil is active

## Reviewers

Needed: 2 reviewers (as per P4233 merge gate)

Tags: enhancement, noise-reduction, community-collab