### PR TITLE
feat(task-market): P4247 Part 2 — add rate_limit metadata to batch-accept response

### DIFF
--- a/internal/server/token_rewards_market.go
+++ b/internal/server/token_rewards_market.go
@@ -1481,7 +1481,19 @@ func (s *Server) handleTokenTaskMarketBatchAccept(w http.ResponseWriter, r *http
 		claimsInWindow++
 		results = append(results, map[string]any{"task_id": taskID, "status": "claimed", "item": proposalImplementationTaskItem(group, &lease)})
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"results": results, "claimed_count": len(results)})
+	// P4247: Include rate limit metadata in batch accept response
+	writeJSON(w, http.StatusOK, map[string]any{
+		"results":       results,
+		"claimed_count": len(results),
+		"rate_limit": map[string]any{
+			"tier":               tier,
+			"max_claims":         maxClaims,
+			"claims_in_window":   claimsInWindow,
+			"remaining":          maxClaims - claimsInWindow,
+			"window_seconds":     int(taskMarketAcceptRateLimitWindow / time.Second),
+			"reset_at_unix":      now.Add(taskMarketAcceptRateLimitWindow).Unix(),
+		},
+	})
 }
 
 func (s *Server) collectManualBountyMarketItems(ctx context.Context, module, status string) []tokenTaskMarketItem {


### PR DESCRIPTION
P4247 Task Market Efficiency Phase 2 implementation. Completes rate limit transparency for the batch-accept endpoint.

**Changes:**
- Add rate_limit object to batch-accept response with tier/max_claims/claims_in_window/remaining/window_seconds/reset_at_unix
- Pairs with Part 1 (PR #191) which added X-RateLimit-* headers globally

**Files changed:**
- internal/server/token_rewards_market.go — batch-accept response includes rate_limit metadata

**Testing:**
- Hit POST /api/v1/token/task-market/batch-accept and verify `rate_limit` object in response body

Collab: collab-4247-auto-1778325204586
Proposal: P4247