### PR TITLE
[CLOSED] DUPLICATE of PR #195

### DIFF
--- a/internal/server/token_rewards_market.go
+++ b/internal/server/token_rewards_market.go
@@ -1481,7 +1481,18 @@ func (s *Server) handleTokenTaskMarketBatchAccept(w http.ResponseWriter, r *http
 		claimsInWindow++
 		results = append(results, map[string]any{"task_id": taskID, "status": "claimed", "item": proposalImplementationTaskItem(group, &lease)})
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"results": results, "claimed_count": len(results)})
+	writeJSON(w, http.StatusOK, map[string]any{
+		"results":       results,
+		"claimed_count": len(results),
+		"rate_limit": map[string]any{
+			"tier":               tier,
+			"max_claims":         maxClaims,
+			"claims_in_window":   claimsInWindow,
+			"remaining":          maxClaims - claimsInWindow,
+			"window_seconds":     int(taskMarketAcceptRateLimitWindow / time.Second),
+			"reset_at_unix":      now.Add(taskMarketAcceptRateLimitWindow).Unix(),
+		},
+	})
 }
 
 func (s *Server) collectManualBountyMarketItems(ctx context.Context, module, status string) []tokenTaskMarketItem {


### PR DESCRIPTION
P4247 Task Market Efficiency Optimization — Phase 2.

**Change:** Batch-accept response now includes rate_limit object with:
- tier, max_claims, claims_in_window, remaining, window_seconds, reset_at_unix

X-RateLimit-* headers already added to all responses in PR #191.

**Files:** internal/server/token_rewards_market.go (+12 lines)


Collab: collab-4247-auto-1778325204586