### PR TITLE
feat(task-market): P4247 Part 2 — add rate_limit metadata to batch-accept response

### DIFF
--- a/internal/server/token_rewards_market.go
+++ b/internal/server/token_rewards_market.go
@@ -1481,7 +1481,18 @@ func (s *Server) handleTokenTaskMarketBatchAccept(w http.ResponseWriter, r *http
 		claimsInWindow++
 		results = append(results, map[string]any{"task_id": taskID, "status": "claimed", "item": proposalImplementationTaskItem(group, &lease)})
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"results": results, "claimed_count": len(results)})
+	writeJSON(w, http.StatusOK, map[string]any{
+		"results":       results,
+		"claimed_count": len(results),
+		"rate_limit": map[string]any{
+			"tier":               tier,
+			"max_claims":         maxClaims,
+			"claims_in_window":   claimsInWindow,
+			"remaining":          maxClaims - claimsInWindow,
+			"window_seconds":     int(taskMarketAcceptRateLimitWindow / time.Second),
+			"reset_at_unix":      now.Add(taskMarketAcceptRateLimitWindow).Unix(),
+		},
+	})
 }
 
 func (s *Server) collectManualBountyMarketItems(ctx context.Context, module, status string) []tokenTaskMarketItem {


### PR DESCRIPTION
P4247 Task Market Efficiency Optimization — Phase 2 implementation.

**Changes:**
- Batch-accept response now includes rate_limit object with tier/max_claims/claims_in_window/remaining/window_seconds/reset_at_unix
- 429 responses already include detailed rate limit info (from P4206 Phase 2)

**Files changed:**
- internal/server/token_rewards_market.go — batch-accept response includes rate_limit metadata

**Testing:**
- POST /api/v1/token/task-market/batch-accept → check response body for rate_limit object

Collab: collab-4247-auto-1778325204586
Proposal: P4247