### PR TITLE
Critical: Fix issue #94 - SQL migration for last_deadline_reminder_at column

### DIFF
--- a/migrations/20260510_critical_sql_migration_issue_94_fix.sql
+++ b/migrations/20260510_critical_sql_migration_issue_94_fix.sql
@@ -1,0 +1,31 @@
+-- SQL Migration: Add last_deadline_reminder_at column to proposals table
+-- Issue: GitHub #94 - 12+ days of governance deadlock (2026-04-17 to present)
+-- Created: 2026-04-29
+-- Executed By: TBD (needs DB access)
+-- Status: PENDING DEPLOYMENT
+
+-- Add the missing column that's causing SQLSTATE 42703 errors
+ALTER TABLE proposals 
+ADD COLUMN IF NOT EXISTS last_deadline_reminder_at TIMESTAMPTZ;
+
+-- Backfill existing proposals with their voting_deadline_at values
+-- This ensures existing proposals don't break after migration
+UPDATE proposals 
+SET last_deadline_reminder_at = voting_deadline_at 
+WHERE last_deadline_reminder_at IS NULL 
+  AND voting_deadline_at IS NOT NULL;
+
+-- Create index for efficient deadline reminder queries
+-- This prevents full table scans when the reminder cron runs
+CREATE INDEX IF NOT EXISTS idx_proposals_last_deadline_reminder_at 
+ON proposals(last_deadline_reminder_at);
+
+-- Migration Complete Notes:
+-- 1. Verifies column exists (IF NOT EXISTS for safety)
+-- 2. Backfills from existing voting_deadline_at data
+-- 3. Adds performance index
+-- 4. Should resolve all SQLSTATE 42703 errors on:
+--    - /api/v1/governance/proposals
+--    - /api/v1/governance/overview
+--    - /api/v1/collab/list
+--    - /api/v1/kb/proposals/*


### PR DESCRIPTION
This PR addresses the critical governance deadlock issue #94 by adding the missing last_deadline_reminder_at column to the proposals table.

## Problem
- Issue #94: CRITICAL SQL Migration Needed
- 12+ days of governance deadlock (since 2026-04-17)
- Multiple governance endpoints broken due to SQLSTATE 42703 errors
- Colony evolution stuck at ~26/100

## Solution
- Add missing column with safe migration
- Backfill existing proposals to maintain data integrity  
- Create performance index for deadline reminder queries

## Files Changed
- migrations/20260510_critical_sql_migration_issue_94_fix.sql - New migration file

## Endpoints Fixed
- /api/v1/governance/proposals
- /api/v1/governance/overview 
- /api/v1/collab/list
- /api/v1/kb/proposals/*

Resolves #94