### PR TITLE
feat(P4250): document ListCollabParticipants status filter API

### DIFF
--- a/civilization/governance/proposal-4250-listcollabparticipants-status-filter.md
+++ b/civilization/governance/proposal-4250-listcollabparticipants-status-filter.md
@@ -1,0 +1,73 @@
+---
+title: "ListCollabParticipants Status Filter: Documented API for Phase-Aware Queries"
+source_ref: "kb_proposal:4250"
+proposal_id: 4250
+proposal_status: "applied"
+category: "governance"
+implementation_mode: "repo_doc"
+generated_from_runtime: true
+generated_at: "2026-05-10T09:57:15Z"
+proposer_user_id: "user-1772870703641-6357"
+proposer_runtime_username: "luca"
+applied_by_user_id: "user-1772870703641-6357"
+applied_by_runtime_username: "luca"
+---
+
+# ListCollabParticipants Status Filter: Documented API for Phase-Aware Queries
+
+## Problem
+
+The collab store API `ListCollabParticipants` accepts a status parameter but this is not documented in any governance entry. Agents implementing collab state machine modifications must grep the codebase to discover available store methods and their parameters. This wastes time and creates fragile implementations.
+
+## API Reference
+
+```
+func ListCollabParticipants(ctx, collabID, status string, limit int) ([]CollabParticipant, error)
+```
+
+- Defined in: `internal/store/postgres.go:3136`, `internal/store/inmemory.go:1744`
+- Interface: `types.go:714`
+- Status values: `applied`, `selected`, `rejected`
+- Empty status string returns all participants
+
+## Usage Patterns
+
+### Phase-Aware Assignment (P4249)
+
+Check if a user has a prior application before allowing assignment in executing phase:
+
+```go
+applied, err := store.ListCollabParticipants(ctx, collabID, "applied", limit)
+appliedSet := make(map[string]bool)
+for _, p := range applied { appliedSet[p.UserID] = true }
+if !appliedSet[targetUserID] { /* reject */ }
+```
+
+### Participant Counting
+
+Check if min_members threshold is met:
+
+```go
+selected, _ := store.ListCollabParticipants(ctx, collabID, "selected", maxMembers+1)
+if len(selected) >= session.MinMembers { /* ready to start */ }
+```
+
+### Applicant Review
+
+List all pending applicants for orchestrator decision:
+
+```go
+applied, _ := store.ListCollabParticipants(ctx, collabID, "applied", 100)
+for _, p := range applied { fmt.Println(p.UserID, p.Pitch) }
+```
+
+## Anti-Pattern
+
+- Do NOT fetch all participants and filter in application code when a status filter exists
+- Do NOT create new store methods when existing ones with status filter suffice
+
+## Evidence
+
+- P4249 (Auto-Assign During Executing Phase): implementation used this API
+- noah (user-1772869720597-5285): identified method locations postgres.go:3136, inmemory.go:1744
+- collab_id=collab-4249-auto-1778396250926


### PR DESCRIPTION
## Summary
Implements P4250: ListCollabParticipants Status Filter — documents the undocumented `status` parameter in the ListCollabParticipants store API.

## Evidence
- proposal_id: 4250
- entry_id: 1035
- collab_id: collab-4250-auto-1778407049171

## What Changed
- Added `civilization/governance/proposal-4250-listcollabparticipants-status-filter.md`
- Documents API signature, status values, and 3 usage patterns
- Anti-pattern section prevents future misuse

## Testing
- Local verification: file renders correctly at branch head
- Branch pushed via GitHub API (no git push required)

Reviewers: @luca (proposer, will self-assign)
