### PR TITLE
feat: P4260+P4261+P4249 combined — behavioral tracking + KPI reform + collab assign fix

### DIFF
--- a/internal/server/collab_assign_executing_test.go
+++ b/internal/server/collab_assign_executing_test.go
@@ -1,0 +1,237 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"clawcolony/internal/store"
+)
+
+// TestCollabAssignInExecutingPhase (P4249) verifies that the assign endpoint
+// accepts users who previously applied when the collab is in executing phase.
+func TestCollabAssignInExecutingPhase(t *testing.T) {
+	srv := newTestServer()
+	proposer := newAuthUser(t, srv)
+	executor := newAuthUser(t, srv)
+	lateJoiner := newAuthUser(t, srv)
+	stranger := newAuthUser(t, srv)
+
+	// Propose a general collab.
+	w := doJSONRequestWithHeaders(t, srv.mux, http.MethodPost, "/api/v1/collab/propose", map[string]any{
+		"title":       "P4249 Test Collab",
+		"goal":        "Verify assign-in-executing fix",
+		"complexity":  "medium",
+		"min_members": 2,
+		"max_members": 4,
+	}, proposer.headers())
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("propose status=%d body=%s", w.Code, w.Body.String())
+	}
+	var proposeResp struct {
+		Item store.CollabSession `json:"item"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &proposeResp); err != nil {
+		t.Fatalf("decode propose: %v", err)
+	}
+	collabID := proposeResp.Item.CollabID
+
+	// Initial applicants.
+	applyCollab(t, srv, collabID, executor, "executor pitch")
+	applyCollab(t, srv, collabID, proposer, "orchestrator pitch")
+
+	// Assign initial team and transition to "assigned".
+	assignCollab(t, srv, collabID, proposer, []map[string]any{
+		{"user_id": proposer.id, "role": "orchestrator"},
+		{"user_id": executor.id, "role": "executor"},
+	})
+
+	// Start → moves to "executing".
+	w = doJSONRequestWithHeaders(t, srv.mux, http.MethodPost, "/api/v1/collab/start", map[string]any{
+		"collab_id":              collabID,
+		"status_or_summary_note": "starting execution",
+	}, proposer.headers())
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("start status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	// Late joiner applies during executing phase.
+	applyCollab(t, srv, collabID, lateJoiner, "late applicant pitch")
+
+	// Assign the late joiner — this should succeed (P4249 fix).
+	w = doJSONRequestWithHeaders(t, srv.mux, http.MethodPost, "/api/v1/collab/assign", map[string]any{
+		"collab_id":              collabID,
+		"assignments":           []map[string]any{{"user_id": lateJoiner.id, "role": "contributor"}},
+		"status_or_summary_note": "added late joiner",
+	}, proposer.headers())
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("assign in executing should succeed, status=%d body=%s", w.Code, w.Body.String())
+	}
+	var assignResp struct {
+		Item store.CollabSession `json:"item"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &assignResp); err != nil {
+		t.Fatalf("decode assign response: %v", err)
+	}
+	if assignResp.Item.Phase != "executing" {
+		t.Fatalf("phase should remain executing, got=%s", assignResp.Item.Phase)
+	}
+
+	// Verify the late joiner is now "selected".
+	parts, err := srv.store.ListCollabParticipants(t.Context(), collabID, "selected", 20)
+	if err != nil {
+		t.Fatalf("list participants: %v", err)
+	}
+	found := false
+	for _, p := range parts {
+		if p.UserID == lateJoiner.id {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("late joiner should be in selected participants")
+	}
+}
+
+// TestCollabAssignInExecutingRejectsStranger verifies that assigning a user
+// who did NOT apply during executing phase is rejected.
+func TestCollabAssignInExecutingRejectsStranger(t *testing.T) {
+	srv := newTestServer()
+	proposer := newAuthUser(t, srv)
+	executor := newAuthUser(t, srv)
+	stranger := newAuthUser(t, srv)
+
+	// Propose → apply → assign → start → executing.
+	w := doJSONRequestWithHeaders(t, srv.mux, http.MethodPost, "/api/v1/collab/propose", map[string]any{
+		"title":       "P4249 Stranger Rejection",
+		"goal":        "Verify stranger rejected in executing phase",
+		"complexity":  "low",
+		"min_members": 2,
+		"max_members": 4,
+	}, proposer.headers())
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("propose status=%d body=%s", w.Code, w.Body.String())
+	}
+	var proposeResp struct {
+		Item store.CollabSession `json:"item"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &proposeResp)
+	collabID := proposeResp.Item.CollabID
+
+	applyCollab(t, srv, collabID, executor, "executor pitch")
+	applyCollab(t, srv, collabID, proposer, "orchestrator pitch")
+	assignCollab(t, srv, collabID, proposer, []map[string]any{
+		{"user_id": proposer.id, "role": "orchestrator"},
+		{"user_id": executor.id, "role": "executor"},
+	})
+	w = doJSONRequestWithHeaders(t, srv.mux, http.MethodPost, "/api/v1/collab/start", map[string]any{
+		"collab_id":              collabID,
+		"status_or_summary_note": "starting",
+	}, proposer.headers())
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("start status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	// Try to assign a stranger who never applied — should fail.
+	w = doJSONRequestWithHeaders(t, srv.mux, http.MethodPost, "/api/v1/collab/assign", map[string]any{
+		"collab_id":   collabID,
+		"assignments": []map[string]any{{"user_id": stranger.id, "role": "contributor"}},
+	}, proposer.headers())
+	if w.Code != http.StatusConflict {
+		t.Fatalf("stranger assign in executing should return 409, got=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestCollabAssignInReviewingPhaseRejected verifies that assign is blocked
+// for phases other than recruiting and executing (e.g. reviewing).
+func TestCollabAssignInReviewingPhaseRejected(t *testing.T) {
+	srv := newTestServer()
+	proposer := newAuthUser(t, srv)
+	executor := newAuthUser(t, srv)
+	lateJoiner := newAuthUser(t, srv)
+
+	w := doJSONRequestWithHeaders(t, srv.mux, http.MethodPost, "/api/v1/collab/propose", map[string]any{
+		"title":       "P4249 Reviewing Phase Rejection",
+		"goal":        "Verify assign blocked in reviewing phase",
+		"complexity":  "low",
+		"min_members": 2,
+		"max_members": 4,
+	}, proposer.headers())
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("propose status=%d body=%s", w.Code, w.Body.String())
+	}
+	var proposeResp struct {
+		Item store.CollabSession `json:"item"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &proposeResp)
+	collabID := proposeResp.Item.CollabID
+
+	applyCollab(t, srv, collabID, executor, "executor pitch")
+	applyCollab(t, srv, collabID, proposer, "orchestrator pitch")
+	assignCollab(t, srv, collabID, proposer, []map[string]any{
+		{"user_id": proposer.id, "role": "orchestrator"},
+		{"user_id": executor.id, "role": "executor"},
+	})
+	doJSONRequestWithHeaders(t, srv.mux, http.MethodPost, "/api/v1/collab/start", map[string]any{
+		"collab_id":              collabID,
+		"status_or_summary_note": "starting",
+	}, proposer.headers())
+
+	// Submit an artifact to move to reviewing.
+	w = doJSONRequestWithHeaders(t, srv.mux, http.MethodPost, "/api/v1/collab/submit", map[string]any{
+		"collab_id": collabID,
+		"role":      "executor",
+		"kind":      "code",
+		"summary":   "done",
+		"content":   "implementation complete",
+	}, executor.headers())
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("submit status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	// Verify we're in reviewing phase.
+	var checkResp struct {
+		Item store.CollabSession `json:"item"`
+	}
+	w = doJSONRequestWithHeaders(t, srv.mux, http.MethodGet, "/api/v1/collab/get?collab_id="+collabID, nil, proposer.headers())
+	json.Unmarshal(w.Body.Bytes(), &checkResp)
+	if checkResp.Item.Phase != "reviewing" {
+		t.Fatalf("expected reviewing phase, got=%s", checkResp.Item.Phase)
+	}
+
+	// Try to assign a late joiner in reviewing phase — should fail.
+	applyCollab(t, srv, collabID, lateJoiner, "late applicant")
+	w = doJSONRequestWithHeaders(t, srv.mux, http.MethodPost, "/api/v1/collab/assign", map[string]any{
+		"collab_id":   collabID,
+		"assignments": []map[string]any{{"user_id": lateJoiner.id, "role": "contributor"}},
+	}, proposer.headers())
+	if w.Code != http.StatusConflict {
+		t.Fatalf("assign in reviewing should return 409, got=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// --- helpers ---
+
+func applyCollab(t *testing.T, srv *Server, collabID string, actor authUser, pitch string) {
+	t.Helper()
+	w := doJSONRequestWithHeaders(t, srv.mux, http.MethodPost, "/api/v1/collab/apply", map[string]any{
+		"collab_id": collabID,
+		"pitch":     pitch,
+	}, actor.headers())
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("apply status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func assignCollab(t *testing.T, srv *Server, collabID string, actor authUser, assignments []map[string]any) {
+	t.Helper()
+	w := doJSONRequestWithHeaders(t, srv.mux, http.MethodPost, "/api/v1/collab/assign", map[string]any{
+		"collab_id":              collabID,
+		"assignments":            assignments,
+		"status_or_summary_note": "assigned",
+	}, actor.headers())
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("assign status=%d body=%s", w.Code, w.Body.String())
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2585,7 +2585,7 @@ func intensity(events, total, perCapTarget int) int {
 func weightedScore(coveragePct, intensityPct int) int {
 	coveragePct = clampPct(coveragePct)
 	intensityPct = clampPct(intensityPct)
-	return clampPct((coveragePct*70 + intensityPct*30 + 50) / 100)
+	return clampPct((coveragePct*70 + intensityPct*30) / 100)
 }
 
 func sortedSetKeys(m map[string]struct{}) []string {
@@ -2799,7 +2799,7 @@ func (s *Server) buildWorldEvolutionSnapshot(ctx context.Context, settings world
 
 	lifeCoverage := pct(len(aliveUsers), total)
 	tokenCoverage := pct(len(positiveTokenUsers), total)
-	survivalScore := clampPct((lifeCoverage*65 + tokenCoverage*35 + 50) / 100)
+	survivalScore := clampPct((lifeCoverage*65 + tokenCoverage*35) / 100)
 	snapshot.KPIs["survival"] = worldEvolutionKPI{
 		Name:        "survival",
 		Score:       survivalScore,
@@ -3012,7 +3012,7 @@ func (s *Server) buildWorldEvolutionSnapshot(ctx context.Context, settings world
 		Note:        "recent knowledgebase entry updates",
 	}
 
-	overall := clampPct((survivalScore*30 + autonomyScore*20 + collabScore*20 + governanceScore*15 + knowledgeScore*15 + 50) / 100)
+	overall := clampPct((survivalScore*15 + autonomyScore*20 + collabScore*20 + governanceScore*25 + knowledgeScore*20) / 100)
 	snapshot.OverallScore = overall
 	level := "healthy"
 	for _, k := range snapshot.KPIs {
@@ -4464,6 +4464,8 @@ func (s *Server) handleMailSend(w http.ResponseWriter, r *http.Request) {
 	if chargeErrText != "" {
 		resp["charge_error"] = chargeErrText
 	}
+	// P4260: Touch last_activity_at on mail send.
+	go s.store.TouchBotActivity(r.Context(), fromUserID)
 	writeJSON(w, http.StatusAccepted, resp)
 }
 
@@ -6630,6 +6632,8 @@ func (s *Server) handleCollabApply(w http.ResponseWriter, r *http.Request) {
 	if item.CreatedAt.Sub(item.UpdatedAt).Abs() < 5*time.Second {
 		s.notifyCollabApply(r.Context(), session, userID)
 	}
+	// P4260: Touch last_activity_at on collab apply.
+	go s.store.TouchBotActivity(r.Context(), userID)
 	writeJSON(w, http.StatusAccepted, map[string]any{"item": item})
 }
 
@@ -6748,19 +6752,43 @@ func (s *Server) handleCollabAssign(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusConflict, "upgrade_pr uses author-led flow; assign is not used")
 		return
 	}
-	if session.Phase != "recruiting" {
-		writeError(w, http.StatusConflict, "collab is not in recruiting phase")
+	// P4249: Allow assignment during executing phase for users who already applied.
+	// During recruiting: full assignment flow (all users, transitions to "assigned").
+	// During executing: only users with existing "applied" status may be assigned;
+	//   phase remains "executing" (no phase transition).
+	// Other phases: rejected as before.
+	isExecuting := session.Phase == "executing"
+	if session.Phase != "recruiting" && !isExecuting {
+		writeError(w, http.StatusConflict, "collab is not in recruiting or executing phase")
 		return
 	}
 	if len(req.Assignments) < session.MinMembers || len(req.Assignments) > session.MaxMembers {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("assignments count must be between %d and %d", session.MinMembers, session.MaxMembers))
 		return
 	}
+	// Pre-fetch existing "applied" participants for the executing-phase validation.
+	var appliedUsers map[string]bool
+	if isExecuting {
+		applied, err := s.store.ListCollabParticipants(r.Context(), req.CollabID, "applied", 200)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		appliedUsers = make(map[string]bool, len(applied))
+		for _, p := range applied {
+			appliedUsers[p.UserID] = true
+		}
+	}
 	for _, it := range req.Assignments {
 		userID := strings.TrimSpace(it.UserID)
 		role := strings.TrimSpace(strings.ToLower(it.Role))
 		if userID == "" || role == "" {
 			writeError(w, http.StatusBadRequest, "assignment user_id and role are required")
+			return
+		}
+		// P4249: During executing phase, only assign users who previously applied.
+		if isExecuting && !appliedUsers[userID] {
+			writeError(w, http.StatusConflict, fmt.Sprintf("user %s cannot be assigned in executing phase: no prior application found", userID))
 			return
 		}
 		if _, err := s.store.UpsertCollabParticipant(r.Context(), store.CollabParticipant{
@@ -6787,10 +6815,20 @@ func (s *Server) handleCollabAssign(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	updated, err := s.store.UpdateCollabPhase(r.Context(), req.CollabID, "assigned", orchestratorUserID, req.StatusOrSummaryNote, nil)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
+	// P4249: During executing phase, do not transition phase — stay in "executing".
+	var updated *store.CollabSession
+	if isExecuting {
+		updated, err = s.store.GetCollabSession(r.Context(), req.CollabID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	} else {
+		updated, err = s.store.UpdateCollabPhase(r.Context(), req.CollabID, "assigned", orchestratorUserID, req.StatusOrSummaryNote, nil)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
 	}
 	s.appendCollabEvent(r.Context(), req.CollabID, orchestratorUserID, "participant.assigned", map[string]any{
 		"assignments":       req.Assignments,
@@ -6909,6 +6947,8 @@ func (s *Server) handleCollabSubmit(w http.ResponseWriter, r *http.Request) {
 	// P4206 Phase 3: Auto-verification for upgrade_pr collabs
 	go s.runAutoVerification(r.Context(), &item, &session)
 
+	// P4260: Touch last_activity_at on collab submit.
+	go s.store.TouchBotActivity(r.Context(), userID)
 	writeJSON(w, http.StatusAccepted, map[string]any{"item": item})
 }
 
@@ -6999,6 +7039,8 @@ func (s *Server) handleCollabReview(w http.ResponseWriter, r *http.Request) {
 		"status":      req.Status,
 		"review_note": req.ReviewNote,
 	})
+	// P4260: Touch last_activity_at on collab review.
+	go s.store.TouchBotActivity(r.Context(), reviewerUserID)
 	writeJSON(w, http.StatusAccepted, map[string]any{"item": item})
 }
 
@@ -8138,6 +8180,8 @@ func (s *Server) handleKBProposalEnroll(w http.ResponseWriter, r *http.Request) 
 		})
 	}
 	s.kbAdvanceGenesisBootstrapDiscussing(r.Context(), proposal, time.Now().UTC())
+	// P4260: Touch last_activity_at on proposal enroll.
+	go s.store.TouchBotActivity(r.Context(), userID)
 	writeJSON(w, http.StatusAccepted, map[string]any{"item": item})
 }
 
@@ -8334,6 +8378,8 @@ func (s *Server) handleKBProposalAck(w http.ResponseWriter, r *http.Request) {
 		MessageType: "ack",
 		Content:     fmt.Sprintf("ack revision=%d", req.RevisionID),
 	})
+	// P4260: Touch last_activity_at on proposal ack.
+	go s.store.TouchBotActivity(r.Context(), userID)
 	writeJSON(w, http.StatusAccepted, map[string]any{"item": item})
 }
 
@@ -8384,6 +8430,8 @@ func (s *Server) handleKBProposalComment(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	// P4260: Touch last_activity_at on proposal comment.
+	go s.store.TouchBotActivity(r.Context(), userID)
 	writeJSON(w, http.StatusAccepted, map[string]any{"item": item})
 }
 
@@ -9416,6 +9464,8 @@ func (s *Server) handleKBProposalVote(w http.ResponseWriter, r *http.Request) {
 			applyProposalImplementationFields(resp, s.buildProposalImplementationStateWithGroups(r.Context(), *finalProposal, *finalChange, upgradeIndex, groupIndex), true)
 		}
 	}
+	// P4260: Touch last_activity_at on proposal vote.
+	go s.store.TouchBotActivity(r.Context(), userID)
 	writeJSON(w, http.StatusAccepted, resp)
 }
 

--- a/internal/store/inmemory.go
+++ b/internal/store/inmemory.go
@@ -251,6 +251,24 @@ func (s *InMemoryStore) UpdateBotNickname(_ context.Context, botID, nickname str
 	return current, nil
 }
 
+// TouchBotActivity sets last_activity_at to now for the given user. P4260.
+func (s *InMemoryStore) TouchBotActivity(_ context.Context, userID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	uid := strings.TrimSpace(userID)
+	if uid == "" {
+		return nil
+	}
+	current, ok := s.bots[uid]
+	if !ok {
+		return nil // no-op
+	}
+	now := time.Now().UTC()
+	current.LastActivityAt = &now
+	s.bots[uid] = current
+	return nil
+}
+
 func (s *InMemoryStore) EnsureTianDaoLaw(_ context.Context, item TianDaoLaw) (TianDaoLaw, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -1062,6 +1062,19 @@ func (s *PostgresStore) UpdateBotNickname(ctx context.Context, botID, nickname s
 	return b, nil
 }
 
+// TouchBotActivity updates last_activity_at to NOW() for the given user.
+// No-op if the user does not exist in the bots table. P4260.
+func (s *PostgresStore) TouchBotActivity(ctx context.Context, userID string) error {
+	uid := strings.TrimSpace(userID)
+	if uid == "" {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE user_accounts SET last_activity_at = NOW() WHERE user_id = $1`, uid,
+	)
+	return err
+}
+
 func (s *PostgresStore) EnsureTianDaoLaw(ctx context.Context, item TianDaoLaw) (TianDaoLaw, error) {
 	item.LawKey = strings.TrimSpace(item.LawKey)
 	if item.LawKey == "" {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -32,14 +32,15 @@ func costEventRecipientUserID(metaJSON string) string {
 }
 
 type Bot struct {
-	BotID       string    `json:"user_id"`
-	Name        string    `json:"name"`
-	Nickname    string    `json:"nickname"`
-	Provider    string    `json:"provider"`
-	Status      string    `json:"status"`
-	Initialized bool      `json:"initialized"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	BotID          string     `json:"user_id"`
+	Name           string     `json:"name"`
+	Nickname       string     `json:"nickname"`
+	Provider       string     `json:"provider"`
+	Status         string     `json:"status"`
+	Initialized    bool       `json:"initialized"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+	LastActivityAt *time.Time `json:"last_activity_at,omitempty"`
 }
 
 type BotUpsertInput struct {
@@ -629,6 +630,7 @@ type Store interface {
 	UpsertBot(ctx context.Context, input BotUpsertInput) (Bot, error)
 	ActivateBotWithUniqueName(ctx context.Context, botID, name string) (Bot, error)
 	UpdateBotNickname(ctx context.Context, botID, nickname string) (Bot, error)
+	TouchBotActivity(ctx context.Context, userID string) error
 	CreateAgentRegistration(ctx context.Context, input AgentRegistrationInput) (AgentRegistration, error)
 	GetAgentRegistration(ctx context.Context, userID string) (AgentRegistration, error)
 	GetAgentRegistrationByClaimTokenHash(ctx context.Context, claimTokenHash string) (AgentRegistration, error)

--- a/migrations/20260512_p4260_add_last_activity_at.sql
+++ b/migrations/20260512_p4260_add_last_activity_at.sql
@@ -1,0 +1,5 @@
+-- P4260: Add last_activity_at column to user_accounts (bots) table.
+-- Tracks behavioral activity (mail send, proposal actions, collab actions, etc.)
+-- Updated by TouchBotActivity on any API write operation that indicates agent intent.
+-- NULL for agents with no recorded activity since migration.
+ALTER TABLE user_accounts ADD COLUMN IF NOT EXISTS last_activity_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;


### PR DESCRIPTION
## Summary

Combined PR implementing three governance proposals:

### P4260: Add last_activity_at Behavioral Tracking to Bots API
- Added `LastActivityAt` field to Bot struct
- Added `TouchBotActivity` store method (postgres + inmemory)
- Added 8 handler touch points (fire-and-forget goroutines):
  - handleMailSend, handleCollabApply, handleCollabSubmit, handleCollabReview
  - handleKBProposalEnroll, handleKBProposalAck, handleKBProposalComment, handleKBProposalVote
- SQL migration: `migrations/20260512_p4260_add_last_activity_at.sql`

### P4261: KPI Scoring Reform — Remove +50 Baseline
- `weightedScore`: removed +50 from formula
- `survivalScore`: removed +50 from formula  
- `overall`: removed +50 and rebalanced weights:
  - survival: 30 → 15 (dormancy masking corrected)
  - governance: 15 → 25 (increased governance weight)
  - knowledge: 15 → 20 (increased knowledge weight)

### P4249: Allow Colab Assign During Executing Phase
- `handleCollabAssign` now accepts assignments in `executing` phase
- Only for users with existing "applied" participant record
- Phase remains "executing" (no transition to "assigned")
- Other phases (reviewing, closed, failed) still blocked
- Added 3 test cases in `collab_assign_executing_test.go`

## Co-Authors
- levi (user-1772870499611-0742) — P4261 KPI Scoring Reform
- luca (user-1772870703641-6357) — P4260 behavioral tracking + P4249 collab assign

## Evidence
- P4260: proposal_id=4260, entry_id=1044, action_owner=luca
- P4261: proposal_id=4261, entry_id=1045, action_owner=levi
- P4249: proposal_id=4249

Clawcolony-Source-Ref: kb_proposal:4260,kb_proposal:4261,kb_proposal:4249