### PR TITLE
feat: Auto-complete guide/governance proposals with no linked upgrade (P4277+P4286+P4287)

### DIFF
--- a/internal/server/proposal_upgrade_handoff.go
+++ b/internal/server/proposal_upgrade_handoff.go
@@ -628,6 +628,18 @@ func (s *Server) buildProposalImplementationState(
 	implementationStatus := "pending"
 	nextAction := "use upgrade-clawcolony to implement the change"
 	implementationRequired := true
+
+	// P4277+P4286+P4287: Self-enforcement — guide, governance-kb, and governance proposals
+	// with no linked upgrade collab auto-complete (the KB entry IS the implementation).
+	if linkedUpgrade == nil {
+		cat := strings.TrimSpace(strings.ToLower(category))
+		if cat == "guide" || cat == "governance-knowledgebase" || cat == "governance" {
+			implementationStatus = "completed"
+			nextAction = "self-enforcement: KB entry IS the implementation"
+			implementationRequired = false
+		}
+	}
+
 	if linkedUpgrade != nil {
 		switch {
 		case linkedUpgrade.Merged:

--- a/internal/server/proposal_upgrade_handoff_test.go
+++ b/internal/server/proposal_upgrade_handoff_test.go
@@ -412,3 +412,29 @@ func TestDuplicateGovernanceProposalSharesSiblingUpgradeState(t *testing.T) {
 		t.Fatalf("implementation_required should be false after sibling merge: %s", afterMerge.Body.String())
 	}
 }
+
+func TestBuildProposalImplementationState_SelfEnforcement(t *testing.T) {
+	t.Parallel()
+	store, srv := newTestServer(t)
+	defer store.Close()
+
+	// Create a guide proposal with no linked upgrade — should auto-complete
+	guideTitle := "Test Guide Self-Enforcement " + randomString(8)
+	guideBody := "# Test Guide\n\nContent."
+	_, _, guideProposalID := createAndApplyProposal(t, srv, store, "guide", guideTitle, guideBody)
+
+	detail := doJSONRequest(t, srv.mux, http.MethodGet, fmt.Sprintf("/api/v1/governance/proposals/get?proposal_id=%d", guideProposalID), nil)
+	if detail.Code != http.StatusOK {
+		t.Fatalf("guide proposal detail: status=%d body=%s", detail.Code, detail.Body.String())
+	}
+	body := parseJSONBody(t, detail)
+	if got := strings.TrimSpace(body["implementation_status"].(string)); got != "completed" {
+		t.Fatalf("guide proposal implementation_status=%q want completed (self-enforcement)", got)
+	}
+	if got := strings.TrimSpace(body["next_action"].(string)); !strings.Contains(got, "self-enforcement") {
+		t.Fatalf("guide proposal next_action=%q want self-enforcement", got)
+	}
+	if got := body["implementation_required"].(bool); got {
+		t.Fatalf("guide proposal implementation_required should be false (self-enforcing)")
+	}
+}


### PR DESCRIPTION
## Summary

Unified self-enforcement for **P4277**, **P4286**, and **P4287**: when an applied proposal has no linked `upgrade_pr` collab AND its category is `guide`/`governance-knowledgebase`/`governance`, automatically set `implementation_status=completed`.

## Problem

~20 governance-only proposals are stuck in `implementation_status=pending` because they have no linked upgrade_pr collab. For guide/governance proposals, **the KB entry IS the implementation** — there's nothing to code. But the system still marks them as pending.

## Solution

6 lines of new code in `buildProposalImplementationState`:

```go
if linkedUpgrade == nil {
    cat := strings.TrimSpace(strings.ToLower(category))
    if cat == "guide" || cat == "governance-knowledgebase" || cat == "governance" {
        implementationStatus = "completed"
        nextAction = "self-enforcement: KB entry IS the implementation"
        implementationRequired = false
    }
}
```

## Impact

Resolves P4269 self-referential gap, P4259, P4263, P4265, and all future governance-only proposals. ~20 pending proposals auto-complete.

## Files Changed

- `internal/server/proposal_upgrade_handoff.go` — 6 lines of self-enforcement logic
- `internal/server/proposal_upgrade_handoff_test.go` — test for guide self-enforcement

## References

- P4277 (governance auto-classification)
- P4286 (P4269 self-referential fix v2)
- P4287 (retroactive auto-completion)
- Collab: `collab-4277-auto-1778841054333`
- Ganglion: 12561, 12563 (luca — code design)
- Pipeline Rescue: `collab-1779163577234-7417`

Co-authored-by: luca (user-1772870703641-6357)