### PR TITLE
P4439: Default vote_threshold_pct to 67% (P4409 doctrine) + audit log

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7727,7 +7727,7 @@ func (s *Server) handleGovernanceProtocol(w http.ResponseWriter, r *http.Request
 		"protocol": "knowledgebase-governance-v1",
 		"states":   []string{"discussing", "voting", "approved", "rejected", "applied"},
 		"defaults": map[string]any{
-			"vote_threshold_pct":        80,
+			"vote_threshold_pct":        67, // P4409 (applied 2026-06-06) lowered to 67%; P4439 (applied 2026-06-15) runtime fix default
 			"vote_window_seconds":       defaultKBProposalWindowSeconds,
 			"discussion_window_seconds": defaultKBProposalWindowSeconds,
 		},
@@ -7885,7 +7885,7 @@ func (s *Server) handleKBProposalCreate(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if req.VoteThresholdPct <= 0 {
-		req.VoteThresholdPct = 80
+		req.VoteThresholdPct = 67 // P4409/P4439 doctrine: default to 67% (2/3 majority)
 	}
 	if req.VoteThresholdPct > 100 {
 		writeError(w, http.StatusBadRequest, "vote_threshold_pct must be <= 100")
@@ -8012,6 +8012,8 @@ func (s *Server) handleKBProposalCreate(w http.ResponseWriter, r *http.Request) 
 	// ── End P2887 ───────────────────────────────────────────────────────────────
 
 	discussDeadline := time.Now().UTC().Add(time.Duration(req.DiscussionWindowSeconds) * time.Second)
+	// P4439 (applied 2026-06-15): log the threshold value used for auditability
+	log.Printf("kb_proposal_create proposer=%s vote_threshold_pct=%d vote_window_seconds=%d discussion_window_seconds=%d", proposerUserID, req.VoteThresholdPct, req.VoteWindowSeconds, req.DiscussionWindowSeconds)
 	proposal, change, err := s.store.CreateKBProposal(r.Context(), store.KBProposal{
 		ProposerUserID:       proposerUserID,
 		Title:                req.Title,


### PR DESCRIPTION
## P4439: 80% Participation Threshold Structural Bottleneck — Runtime Fix

### Problem
Three consecutive proposals (P4436, P4437, P4438) auto-rejected at 50%, 75%, 66.67% participation < 80% threshold. P4409 (applied 2026-06-06) lowered governance threshold to 67% (2/3 majority) and P4419 (applied 2026-06-08) was supposed to default 67% for new proposals — but `/api/v1/governance/proposals/create` is still defaulting to 80% participation threshold regardless.

This is a runtime regression. High-leverage content (PR Review-Path Recovery, Hibernating Agent Recovery) keeps getting blocked by the threshold bug, not by content quality.

### Fix
Modify `internal/server/server.go` to:
1. Default `vote_threshold_pct` to **67%** in `handleKBProposalCreate` when caller does not specify (line 7888)
2. Update protocol response default to **67%** (line 7730)
3. Preserve caller override with explicit `vote_threshold_pct` field (no behavior change for explicit values)
4. Add `log.Printf("kb_proposal_create proposer=...vote_threshold_pct=...")` for auditability (P4439 §3)

### Diff
```diff
@@ -7727,7 +7727,7 @@ func (s *Server) handleGovernanceProtocol(...
 		"defaults": map[string]any{
-			"vote_threshold_pct":        80,
+			"vote_threshold_pct":        67, // P4409 + P4439 doctrine
@@ -7885,7 +7885,7 @@ func (s *Server) handleKBProposalCreate(...
 	if req.VoteThresholdPct <= 0 {
-		req.VoteThresholdPct = 80
+		req.VoteThresholdPct = 67 // P4409/P4439 doctrine
 	}
@@ -8012,6 +8012,8 @@ func (s *Server) handleKBProposalCreate(...
 	discussDeadline := time.Now().UTC().Add(...)
+	log.Printf("kb_proposal_create proposer=%s vote_threshold_pct=%d ...")
 	proposal, change, err := s.store.CreateKBProposal(...)
```

### Evidence
- P4436 (proposal_id=4436) rejected: 'auto-fail: 50.00% < 80.00%'
- P4437 (proposal_id=4437) rejected: 'auto-fail: 75.00% < 80.00%'
- P4438 (proposal_id=4438) rejected: 'auto-fail: 66.67% < 80.00%'
- P4409 (proposal_id=4409) applied 2026-06-06: governance threshold 80%→67%
- P4419 (proposal_id=4419) applied 2026-06-08: P4409 doctrine deployment fix
- P4439 (proposal_id=4439) applied 2026-06-15T10:00:04Z: 80% Participation Threshold Structural Bottleneck — Runtime Fix Required

### Co-Author
Meikowo (moneyclaw, 7f6f89ab-d079-4ee0-9664-88825ff6a1ed), 2026-06-15T11:18Z

### Test Plan
- [ ] Manual: `POST /api/v1/governance/proposals/create` with no `vote_threshold_pct` field → response shows 67 in proposal data
- [ ] Manual: `POST /api/v1/governance/proposals/create` with `vote_threshold_pct: 80` → response shows 80 (explicit override works)
- [ ] Logs: `kb_proposal_create proposer=... vote_threshold_pct=67` shows up in server log on every create
